### PR TITLE
Replaced DateTime with Get-Date to account for Localised DateTime Format

### DIFF
--- a/1-DeployAndConfigureAzureResources.ps1
+++ b/1-DeployAndConfigureAzureResources.ps1
@@ -367,7 +367,7 @@ Process
                     Write-Host -ForegroundColor Yellow "`t* No valid certificate path was provided. Creating a new self-signed certificate and converting to Base64 string"
                     $fileName = "appgwfrontendssl"
                     $certificate = New-SelfSignedCertificateEx -Subject "CN=www.$customHostName" -SAN "www.$customHostName" -EKU "Server Authentication", "Client authentication" `
-                    -NotAfter $([datetime]::now.AddYears(5)) -KU "KeyEncipherment, DigitalSignature" -SignatureAlgorithm SHA256 -Exportable
+                    -NotAfter $((Get-Date).AddYears(5)) -KU "KeyEncipherment, DigitalSignature" -SignatureAlgorithm SHA256 -Exportable
                     $certThumbprint = "cert:\CurrentUser\my\" + $certificate.Thumbprint
                     Write-Host -ForegroundColor Yellow "`t* Certificate created successfully. Exporting certificate into pfx format."
                     Export-PfxCertificate -cert $certThumbprint -FilePath "$scriptFolder\Certificates\$fileName.pfx" -Password $secNewPasswd | Out-null
@@ -384,7 +384,7 @@ Process
             Write-Host -ForegroundColor Yellow "`t* Creating a self-signed certificate for ASE ILB and converting to Base64 string"
             $fileName = "aseilbcertificate"
             $certificate = New-SelfSignedCertificateEx -Subject "CN=*.ase.$customHostName" -SAN "*.ase.$customHostName", "*.scm.ase.$customHostName" -EKU "Server Authentication", "Client authentication" `
-            -NotAfter $([datetime]::now.AddYears(5)) -KU "KeyEncipherment, DigitalSignature" -SignatureAlgorithm SHA256 -Exportable
+            -NotAfter $((Get-Date).AddYears(5)) -KU "KeyEncipherment, DigitalSignature" -SignatureAlgorithm SHA256 -Exportable
             $certThumbprint = "cert:\CurrentUser\my\" + $certificate.Thumbprint
             Write-Host -ForegroundColor Yellow "`t* Certificate created successfully. Exporting certificate into .pfx & .cer format."
             Export-PfxCertificate -cert $certThumbprint -FilePath "$scriptFolder\Certificates\$fileName.pfx" -Password $secNewPasswd | Out-null

--- a/1-click-deployment-nested/New-RunAsAccount.ps1
+++ b/1-click-deployment-nested/New-RunAsAccount.ps1
@@ -51,7 +51,7 @@
 
  $KeyCredential = New-Object  Microsoft.Azure.Commands.Resources.Models.ActiveDirectory.PSADKeyCredential
  $KeyCredential.StartDate = $CurrentDate
- $KeyCredential.EndDate= [DateTime]$PfxCert.GetExpirationDateString()
+ $KeyCredential.EndDate= Get-Date $PfxCert.GetExpirationDateString()
  $KeyCredential.EndDate = $KeyCredential.EndDate.AddDays(-1)
  $KeyCredential.KeyId = $KeyId
  $KeyCredential.CertValue  = $keyValue

--- a/1-click-deployment-nested/New-SelfSignedCertificateEx.ps1
+++ b/1-click-deployment-nested/New-SelfSignedCertificateEx.ps1
@@ -122,7 +122,7 @@ function New-SelfSignedCertificateEx {
 	exportable keys.
 .Example
 	New-SelfsignedCertificateEx -Subject "CN=Test Code Signing" -EKU "Code Signing" -KeySpec "Signature" `
-	-KeyUsage "DigitalSignature" -FriendlyName "Test code signing" -NotAfter $([datetime]::now.AddYears(5))
+	-KeyUsage "DigitalSignature" -FriendlyName "Test code signing" -NotAfter $((Get-Date).AddYears(5))
 	
 	Creates a self-signed certificate intended for code signing and which is valid for 5 years. Certificate
 	is saved in the Personal store of the current user account.
@@ -159,9 +159,9 @@ function New-SelfSignedCertificateEx {
 		[Parameter(Mandatory = $true, Position = 0)]
 		[string]$Subject,
 		[Parameter(Position = 1)]
-		[datetime]$NotBefore = [DateTime]::Now.AddDays(-1),
+		$NotBefore = (Get-Date).AddDays(-1),
 		[Parameter(Position = 2)]
-		[datetime]$NotAfter = $NotBefore.AddDays(365),
+		$NotAfter = $NotBefore.AddDays(365),
 		[string]$SerialNumber,
 		[Alias('CSP')]
 		[string]$ProviderName = "Microsoft Enhanced Cryptographic Provider v1.0",


### PR DESCRIPTION
Fix for [Issue 5: New-RunAsAccount.ps1 throws exception System.Excpetion](https://github.com/AvyanConsultingCorp/pci-paas-webapp-ase-sqldb-appgateway-keyvault-oms/issues/5).

Usages of DateTime replaced with Get-Date to account for Localized DateTime Format 